### PR TITLE
Update element.rb to 1.11.96

### DIFF
--- a/Casks/e/element.rb
+++ b/Casks/e/element.rb
@@ -1,6 +1,6 @@
 cask "element" do
-  version "1.11.95"
-  sha256 "31930ca3aab27ce4687960b92920801f9b2d6b1869f4781812f0bc280fed9c3d"
+  version "1.11.96"
+  sha256 "8c39e9a6747db5213baaa83f77e3ef78651461f9f9d135e7e05ad2084bed48bb"
 
   url "https://packages.element.io/desktop/update/macos/Element-#{version}-universal-mac.zip"
   name "Element"


### PR DESCRIPTION
According to https://github.com/element-hq/element-desktop/releases and https://packages.element.io/desktop/update/macos/releases.js the newest version is currently 1.11.96. 

```bash
$ curl --silent https://packages.element.io/desktop/update/macos/releases.json | jq .currentRelease
"1.11.96"
```

```bash
$ sha256sum Element-1.11.96-universal-mac.zip
8c39e9a6747db5213baaa83f77e3ef78651461f9f9d135e7e05ad2084bed48bb  Element-1.11.96-universal-mac.zip
```

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

---
